### PR TITLE
Fix rounding errors

### DIFF
--- a/transa.sh
+++ b/transa.sh
@@ -34,7 +34,7 @@ then
         UYU=$(echo "$1" | cut -c 2-) # Drop the initial `$` from the input.
         USD=$(echo "scale=2; (${UYU} / ${MEAN})" | bc --mathlib)
     else
-        USD=$1
+        USD=$(printf %.2f "$1")
         UYU=$(printf %.2f "$(echo "(${USD} * ${MEAN})" | bc --mathlib)")
     fi
     echo "TRANSA: U\$S $USD = $ $UYU"

--- a/transa.sh
+++ b/transa.sh
@@ -18,8 +18,7 @@ SELL=$(echo "$BUYSELL_LINES" | tail -n 1)
 MEAN_EXPR="(${BUY} + ${SELL}) / 2"
 
 # --mathlib is for bc to use decimals properly
-# scale=2 is for bc to restrict results to 2 decimal digits.
-MEAN=$(echo "scale=2; ${MEAN_EXPR}" | bc --mathlib)
+MEAN=$(echo "${MEAN_EXPR}" | bc --mathlib)
 
 echo "Itaú compra y venta: ${BUY}, ${SELL}"
 
@@ -36,7 +35,7 @@ then
         USD=$(echo "scale=2; (${UYU} / ${MEAN})" | bc --mathlib)
     else
         USD=$1
-        UYU=$(echo "scale=2; (${USD} * ${MEAN})" | bc --mathlib)
+        UYU=$(printf %.2f "$(echo "(${USD} * ${MEAN})" | bc --mathlib)")
     fi
     echo "TRANSA: U\$S $USD = $ $UYU"
 fi

--- a/transa.sh
+++ b/transa.sh
@@ -30,8 +30,11 @@ beginswith() { case "$2" in "$1"*) true;; *) false;; esac; }
 
 if [ -n "$1" ]
 then
+    # `printf %.2f` rounds the input to two decimal places.
+
     if beginswith "$" "$1"; then
-        UYU=$(echo "$1" | cut -c 2-) # Drop the initial `$` from the input.
+        # The `cut` command drops the initial `$` from the input.
+        UYU=$(printf %.2f "$(echo "$1" | cut -c 2-)")
         USD=$(echo "scale=2; (${UYU} / ${MEAN})" | bc --mathlib)
     else
         USD=$(printf %.2f "$1")

--- a/transa.sh
+++ b/transa.sh
@@ -35,7 +35,7 @@ then
     if beginswith "$" "$1"; then
         # The `cut` command drops the initial `$` from the input.
         UYU=$(printf %.2f "$(echo "$1" | cut -c 2-)")
-        USD=$(echo "scale=2; (${UYU} / ${MEAN})" | bc --mathlib)
+        USD=$(printf %.2f "$(echo "(${UYU} / ${MEAN})" | bc --mathlib)")
     else
         USD=$(printf %.2f "$1")
         UYU=$(printf %.2f "$(echo "(${USD} * ${MEAN})" | bc --mathlib)")


### PR DESCRIPTION
# What this PR does

This fixes #2 and other rounding errors, namely:
- Mean was being rounded! -> The bank supports wires up to 2 decimal digits which, for some reason, led me to round the intermediate mean computation. This is not correct since, when multiplying/deviding to compute the output, it can propagate the rounding error to the result.
  - Transa results should be rounded to two decimal digits instead.
- Inputs should be rounded to 2 decimal digits as well -> Given the above mentioned bank restriction.

