### PR TITLE
Add BCU support to transa.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
 # transa-script
-Shell script to compute the Itaú & BROU mean [USD](https://en.wikipedia.org/wiki/United_States_dollar)/[UYU](https://en.wikipedia.org/wiki/Uruguayan_peso) exchange rate.
+Shell script to compute the mean [USD](https://en.wikipedia.org/wiki/United_States_dollar)/[UYU](https://en.wikipedia.org/wiki/Uruguayan_peso) exchange rate from many Uruguayan rate providers.
 
 ## Usage
 
 ```
 # General usage:
-transa [<amount>] [itau|brou] [-j|--json]"
+transa [<amount>] [itau|brou|bcu] [-j|--json]"
 
 # Get exchange rates only
 transa # Defaults to itau
 transa itau
 transa brou
+transa bcu
 
 # Exchange rates + calculation for a certain amount
 transa <amount> # Defaults to itau
 transa <amount> brou
 transa <amount> itau
+transa <amount> bcu
 ```
+
+## Supported providers
+
+- [ITAÚ Uruguay](https://www.itau.com.uy/) (default).
+- [BROU](https://www.brou.com.uy/).
+- [BCU](https://www.bcu.gub.uy/) (Banco Central del Uruguay).
 
 ## Installation
 
@@ -39,7 +47,7 @@ Notes:
   "created_at":     string, # Date the script completed in ISO 8601 format.
   "results": [
     {
-      "bank":             string, # Possible values: "itau", "brou"
+      "bank":             string, # Possible values: "itau", "brou", "bcu"
       "buy":              float,
       "sell":             float,
       "computed_mean":    float,


### PR DESCRIPTION
# Summary
This PR adds support for a new exchange provider: BCU (Banco Central del Uruguay). This provides the real, unaffected by rounding, interbank exchange rate.

Close #16.

# Questions
1. If we wanted to use `jq`, that part of code could be replaced by 
    ```bash
        BUY=$(echo $response | jq '.cotizacionesoutlist.Cotizaciones | sort_by(.Fecha) | last | .TCC')
        SELL=$(echo $response | jq '.cotizacionesoutlist.Cotizaciones | sort_by(.Fecha) | last | .TCV')
    ```
    We'd have to add an error message for `jq` not installed, but it would also allow for easier error handling in case we don't find any rate in the past 7 days (BCU returns status code 0 in the `RespuestaStatus` field). What do you prefer?
